### PR TITLE
feat: Add support for dynamic page indexing and add favorites view

### DIFF
--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -3,12 +3,15 @@ import 'package:cinemapedia/presentation/screens/movie_screen.dart';
 import 'package:go_router/go_router.dart';
 
 final approuter = GoRouter(
-  initialLocation: '/',
+  initialLocation: '/home/0',
   routes: [
     GoRoute(
-      path: '/',
+      path: '/home/:page',
       name: 'home-screen',
-      builder: (context, state) => const HomeScreen(),
+      builder: (context, state) {
+        final pageIndex = int.tryParse(state.pathParameters['page'] ?? '0') ?? 0;
+        return HomeScreen(pageIndex: pageIndex);
+      },
       routes: [
         GoRoute(
           path: 'movie/:id',
@@ -20,5 +23,9 @@ final approuter = GoRouter(
         )
       ]
     ),
+    GoRoute(
+      path: '/',
+      redirect: (_, _) => '/home/0' 
+    )
   ]
 );

--- a/lib/presentation/screens/home_screen.dart
+++ b/lib/presentation/screens/home_screen.dart
@@ -1,109 +1,27 @@
-import 'package:cinemapedia/presentation/providers/first_load_provider.dart';
-import 'package:cinemapedia/presentation/providers/movies_providers.dart';
-import 'package:cinemapedia/presentation/providers/movies_slideshow_provider.dart';
-import 'package:cinemapedia/presentation/screens/full_screen_loader.dart';
-import 'package:cinemapedia/presentation/widgets/movies_horizontal_listview.dart';
-import 'package:cinemapedia/presentation/widgets/movies_sildeshow.dart';
-import 'package:cinemapedia/presentation/widgets/shared/custom_appbar.dart';
+import 'package:cinemapedia/presentation/views/favorites_movies_view.dart';
+import 'package:cinemapedia/presentation/views/home_view.dart';
 import 'package:cinemapedia/presentation/widgets/shared/custom_bottom_navbar.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
+  final int pageIndex;
+
+  const HomeScreen({super.key, required this.pageIndex});
+
+  final List<Widget> viewRoutes = const [
+    HomeView(),
+    SizedBox(),
+    FavoritesMoviesView()
+  ];
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: _HomeView(),
-      bottomNavigationBar: CustomBottomNavbar(),
-    );
-  }
-}
-
-class _HomeView extends ConsumerStatefulWidget {
-  const _HomeView();
-
-  @override
-  _HomeViewState createState() => _HomeViewState();
-}
-
-class _HomeViewState extends ConsumerState<_HomeView> {
-  @override
-  void initState() {
-    super.initState();
-    ref.read(nowPlayingMoviesProvider.notifier).loadNextPage();
-    ref.read(popularMoviesProvider.notifier).loadNextPage();
-    ref.read(upcomingMoviesProvider.notifier).loadNextPage();
-    ref.read(topRatedMoviesProvider.notifier).loadNextPage();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final isLoading = ref.watch(firstLoadProvider);
-    
-    if (isLoading) {
-      return const FullScreenLoader();
-    }
-
-    final slideshowMovies = ref.watch(moviesSlideshoProvider);
-    final nowPlayingMovies = ref.watch(nowPlayingMoviesProvider);
-    final popularMovies = ref.watch(popularMoviesProvider);
-    final upcomingMovies = ref.watch(upcomingMoviesProvider);
-    final topRatedMovies = ref.watch(topRatedMoviesProvider);
-
-    return CustomScrollView(
-      slivers: [
-        SliverAppBar(
-          floating: true,
-          flexibleSpace: const FlexibleSpaceBar(
-            title: CustomAppBar()
-          )
-        ),
-        SliverList(
-          delegate: SliverChildBuilderDelegate((context, index) {
-            return Column(
-              children: [
-                MoviesSlideWidget(movies: slideshowMovies),
-                MoviesHorizontalListView(
-                  movies: nowPlayingMovies,
-                  title: 'Now in Theatres',
-                  subtitle: 'Today',
-                  loadNextPage: () {
-                    ref.read(nowPlayingMoviesProvider.notifier).loadNextPage();
-                  }
-                ),
-                MoviesHorizontalListView(
-                  movies: upcomingMovies,
-                  title: 'Upcoming Movies',
-                  subtitle: 'Next month',
-                  loadNextPage: () {
-                    ref.read(upcomingMoviesProvider.notifier).loadNextPage();
-                  }
-                ),
-                MoviesHorizontalListView(
-                  movies: popularMovies,
-                  title: 'Popular Movies',
-                  subtitle: 'Today',
-                  loadNextPage: () {
-                    ref.read(popularMoviesProvider.notifier).loadNextPage();
-                  }
-                ),
-                MoviesHorizontalListView(
-                  movies: topRatedMovies,
-                  title: 'Top Rated Movies',
-                  subtitle: 'All time',
-                  loadNextPage: () {
-                    ref.read(topRatedMoviesProvider.notifier).loadNextPage();
-                  }
-                ),
-                const SizedBox(height: 10)
-              ]
-            );
-          },
-          childCount: 1)
-        )
-      ]
+      body: IndexedStack(
+        index: pageIndex,
+        children: viewRoutes,
+      ),
+      bottomNavigationBar: CustomBottomNavbar(currentIndex: pageIndex),
     );
   }
 }

--- a/lib/presentation/views/favorites_movies_view.dart
+++ b/lib/presentation/views/favorites_movies_view.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class FavoritesMoviesView extends StatelessWidget {
+  const FavoritesMoviesView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Favorite Movies'),
+      ),
+      body: Center(
+        child: Text('No favorite movies yet.'),
+      ),
+    );
+  }
+}

--- a/lib/presentation/views/home_view.dart
+++ b/lib/presentation/views/home_view.dart
@@ -1,0 +1,96 @@
+import 'package:cinemapedia/presentation/providers/first_load_provider.dart';
+import 'package:cinemapedia/presentation/providers/movies_providers.dart';
+import 'package:cinemapedia/presentation/providers/movies_slideshow_provider.dart';
+import 'package:cinemapedia/presentation/screens/full_screen_loader.dart';
+import 'package:cinemapedia/presentation/widgets/movies_horizontal_listview.dart';
+import 'package:cinemapedia/presentation/widgets/movies_sildeshow.dart';
+import 'package:cinemapedia/presentation/widgets/shared/custom_appbar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class HomeView extends ConsumerStatefulWidget {
+  const HomeView({super.key});
+
+  @override
+  HomeViewState createState() => HomeViewState();
+}
+
+class HomeViewState extends ConsumerState<HomeView> {
+  @override
+  void initState() {
+    super.initState();
+    ref.read(nowPlayingMoviesProvider.notifier).loadNextPage();
+    ref.read(popularMoviesProvider.notifier).loadNextPage();
+    ref.read(upcomingMoviesProvider.notifier).loadNextPage();
+    ref.read(topRatedMoviesProvider.notifier).loadNextPage();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isLoading = ref.watch(firstLoadProvider);
+    
+    if (isLoading) {
+      return const FullScreenLoader();
+    }
+
+    final slideshowMovies = ref.watch(moviesSlideshoProvider);
+    final nowPlayingMovies = ref.watch(nowPlayingMoviesProvider);
+    final popularMovies = ref.watch(popularMoviesProvider);
+    final upcomingMovies = ref.watch(upcomingMoviesProvider);
+    final topRatedMovies = ref.watch(topRatedMoviesProvider);
+
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          floating: true,
+          flexibleSpace: const FlexibleSpaceBar(
+            title: CustomAppBar()
+          )
+        ),
+        SliverList(
+          delegate: SliverChildBuilderDelegate((context, index) {
+            return Column(
+              children: [
+                MoviesSlideWidget(movies: slideshowMovies),
+                MoviesHorizontalListView(
+                  movies: nowPlayingMovies,
+                  title: 'Now in Theatres',
+                  subtitle: 'Today',
+                  loadNextPage: () {
+                    ref.read(nowPlayingMoviesProvider.notifier).loadNextPage();
+                  }
+                ),
+                MoviesHorizontalListView(
+                  movies: upcomingMovies,
+                  title: 'Upcoming Movies',
+                  subtitle: 'Next month',
+                  loadNextPage: () {
+                    ref.read(upcomingMoviesProvider.notifier).loadNextPage();
+                  }
+                ),
+                MoviesHorizontalListView(
+                  movies: popularMovies,
+                  title: 'Popular Movies',
+                  subtitle: 'Today',
+                  loadNextPage: () {
+                    ref.read(popularMoviesProvider.notifier).loadNextPage();
+                  }
+                ),
+                MoviesHorizontalListView(
+                  movies: topRatedMovies,
+                  title: 'Top Rated Movies',
+                  subtitle: 'All time',
+                  loadNextPage: () {
+                    ref.read(topRatedMoviesProvider.notifier).loadNextPage();
+                  }
+                ),
+                const SizedBox(height: 10)
+              ]
+            );
+          },
+          childCount: 1)
+        )
+      ]
+    );
+  }
+}

--- a/lib/presentation/widgets/movies_horizontal_listview.dart
+++ b/lib/presentation/widgets/movies_horizontal_listview.dart
@@ -97,7 +97,7 @@ class _Slide extends StatelessWidget {
                     );
                   }
                   return GestureDetector(
-                    onTap: () => context.push('/movie/${movie.id}'),
+                    onTap: () => context.push('/home/0/movie/${movie.id}'),
                     child: FadeIn(child: child),
                   );
                 }

--- a/lib/presentation/widgets/shared/custom_bottom_navbar.dart
+++ b/lib/presentation/widgets/shared/custom_bottom_navbar.dart
@@ -1,12 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 class CustomBottomNavbar extends StatelessWidget {
-  const CustomBottomNavbar({super.key});
+  final int currentIndex;
+
+  const CustomBottomNavbar({super.key, required this.currentIndex});
+
+  void _onItemTapped(BuildContext context, int index) {
+    context.go('/home/$index');
+  }
 
   @override
   Widget build(BuildContext context) {
     return BottomNavigationBar(
       elevation: 0.0,
+      onTap: (value) => _onItemTapped(context, value),
       items: const [
         BottomNavigationBarItem(
           icon: Icon(Icons.home_max),


### PR DESCRIPTION
This pull request refactors the navigation system and improves the structure of the `HomeScreen` by introducing views for different sections, such as home and favorites. Additionally, it updates routing logic and simplifies the codebase by separating concerns.

### Navigation Updates:
* [`lib/config/router/app_router.dart`](diffhunk://#diff-c37fa1acc33e70ca0c7462d32dc101d3860d37b18a424c737bd87aa95b3518a5L6-R14): Updated the initial route to `/home/0` and changed the home path to `/home/:page` to support dynamic page indexing. Added a redirect route from `/` to `/home/0`. [[1]](diffhunk://#diff-c37fa1acc33e70ca0c7462d32dc101d3860d37b18a424c737bd87aa95b3518a5L6-R14) [[2]](diffhunk://#diff-c37fa1acc33e70ca0c7462d32dc101d3860d37b18a424c737bd87aa95b3518a5R26-R29)
* [`lib/presentation/widgets/shared/custom_bottom_navbar.dart`](diffhunk://#diff-45464594e9de12109915e46e663af7c51b680d7c759f503a0ff1edf91a7b3d27R2-R17): Modified the `CustomBottomNavbar` to include page navigation logic based on the selected index using `context.go('/home/$index')`.

### HomeScreen Refactor:
* [`lib/presentation/screens/home_screen.dart`](diffhunk://#diff-8db86b900291ef1570ce04338ffa14230d10474324a27c0bed3eac95e954fe39L1-R24): Replaced the previous implementation with an `IndexedStack` to manage views dynamically based on `pageIndex`. Introduced `viewRoutes` containing `HomeView` and `FavoritesMoviesView`.

### View Separation:
* [`lib/presentation/views/home_view.dart`](diffhunk://#diff-787aae5d3b8d17e1aeb68121d4065f38c1c6433a3862e124f8a40dfdeadffa91R1-R96): Moved the previous `HomeScreen` logic into a new `HomeView` class, preserving functionality for loading and displaying movie data.
* [`lib/presentation/views/favorites_movies_view.dart`](diffhunk://#diff-d8bf5e41b0f7b2d7c7093d06e2dbf34c18affa2d733c26d3abed9155f6138236R1-R17): Added a new `FavoritesMoviesView` to display a placeholder for favorite movies.

### Route Adjustments:
* [`lib/presentation/widgets/movies_horizontal_listview.dart`](diffhunk://#diff-29256058ddd74dd66ce155bfa8e26638f305bf6c3785bc0a59a5f4ece2565509L100-R100): Updated movie detail navigation to prepend `/home/0` to the route, ensuring consistency with the new routing structure.